### PR TITLE
Add synchronous API support

### DIFF
--- a/compiler/src/main/java/com/malinskiy/sheldon2/codegen/Utils.java
+++ b/compiler/src/main/java/com/malinskiy/sheldon2/codegen/Utils.java
@@ -4,6 +4,7 @@ import com.google.auto.common.MoreTypes;
 
 import com.malinskiy.sheldon2.annotation.Default;
 import com.malinskiy.sheldon2.annotation.Get;
+import com.malinskiy.sheldon2.annotation.JustGet;
 import com.malinskiy.sheldon2.annotation.Set;
 
 import javax.lang.model.element.ExecutableElement;
@@ -31,6 +32,13 @@ public class Utils {
         return getType(isSetter ? method.getParameters().get(0).asType() : MoreTypes.asDeclared(method.getReturnType()).getTypeArguments().get(0));
     }
 
+    /**
+     * Get preference type from method element
+     */
+    public static PrefType getRawType(ExecutableElement method) {
+        return getType(method.getReturnType());
+    }
+
     private static PrefType getType(TypeMirror type) {
         if (MoreTypes.isTypeOf(Boolean.class, type)) {
             return PrefType.BOOLEAN;
@@ -53,13 +61,16 @@ public class Utils {
     public static String getName(ExecutableElement method) throws ProcessingException {
         Get getAnnotation = method.getAnnotation(Get.class);
         Set setAnnotation = method.getAnnotation(Set.class);
+        JustGet justGetAnnotation = method.getAnnotation(JustGet.class);
 
-        if (getAnnotation == null && setAnnotation == null) {
-            throw new ProcessingException(method, "No annotations present. Should be either @Get or @Set");
+        if (getAnnotation == null && setAnnotation == null && justGetAnnotation == null) {
+            throw new ProcessingException(method, "No annotations present. Should be either @Get or @Set or @JustGet");
         } else if (getAnnotation == null && setAnnotation != null) {
             return setAnnotation.name();
         } else if (getAnnotation != null && setAnnotation == null) {
             return getAnnotation.name();
+        } else if (justGetAnnotation != null) {
+            return justGetAnnotation.name();
         } else {
             throw new ProcessingException(method, "Method annotated with @Get and @Set");
         }

--- a/compiler/src/main/java/com/malinskiy/sheldon2/codegen/model/Contains.java
+++ b/compiler/src/main/java/com/malinskiy/sheldon2/codegen/model/Contains.java
@@ -30,9 +30,10 @@ public class Contains implements Generatable {
         builder.addMethod(
                 MethodSpec.methodBuilder(method.getSimpleName().toString())
                           .addModifiers(Modifier.PUBLIC)
+                          .addAnnotation(Override.class)
                           .addParameter(String.class, "key")
                           .returns(ParameterizedTypeName.get(Observable.class, Boolean.class))
-                          .addStatement("return " + providerFieldName + ".contains($N)", "key")
+                          .addStatement("return " + providerFieldName + ".containsAsObservable($N)", "key")
                           .build());
     }
 

--- a/compiler/src/main/java/com/malinskiy/sheldon2/codegen/model/JustContains.java
+++ b/compiler/src/main/java/com/malinskiy/sheldon2/codegen/model/JustContains.java
@@ -1,0 +1,32 @@
+package com.malinskiy.sheldon2.codegen.model;
+
+import com.google.common.base.Preconditions;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.annotation.Nonnull;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+
+public class JustContains implements Generatable {
+
+    @Nonnull private final ExecutableElement method;
+    @Nonnull private final String providerFieldName;
+
+    public JustContains(@Nonnull ExecutableElement method,
+                        @Nonnull String providerFieldName) {
+
+        this.method = Preconditions.checkNotNull(method);
+        this.providerFieldName = Preconditions.checkNotNull(providerFieldName);
+    }
+
+    @Override public void generateCode(TypeSpec.Builder builder) {
+        builder.addMethod(MethodSpec.methodBuilder(method.getSimpleName().toString())
+                .addModifiers(Modifier.PUBLIC)
+                .addAnnotation(Override.class)
+                .addParameter(String.class, "key")
+                .returns(Boolean.class)
+                .addStatement("return " + providerFieldName + ".contains($N)", "key")
+                .build());
+    }
+}

--- a/compiler/src/main/java/com/malinskiy/sheldon2/codegen/model/ObservableGetter.java
+++ b/compiler/src/main/java/com/malinskiy/sheldon2/codegen/model/ObservableGetter.java
@@ -1,7 +1,7 @@
 package com.malinskiy.sheldon2.codegen.model;
 
-import com.google.auto.common.MoreTypes;
 import com.google.common.base.Preconditions;
+
 import com.malinskiy.sheldon2.codegen.PrefType;
 import com.malinskiy.sheldon2.codegen.ProcessingException;
 import com.malinskiy.sheldon2.codegen.Utils;
@@ -10,15 +10,12 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-
 import javax.annotation.Nonnull;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;
 
-public class Getter implements Generatable {
+public class ObservableGetter implements Generatable {
 
     @Nonnull private final String namespace;
     @Nonnull private final ExecutableElement method;
@@ -26,11 +23,11 @@ public class Getter implements Generatable {
     @Nonnull private final DefaultValue defaultValue;
     @Nonnull private final ClassName repositoryClassName;
 
-    public Getter(@Nonnull String namespace,
-                  @Nonnull ExecutableElement method,
-                  @Nonnull String providerFieldName,
-                  @Nonnull DefaultValue defaultValue,
-                  @Nonnull ClassName repositoryClassName) {
+    public ObservableGetter(@Nonnull String namespace,
+                            @Nonnull ExecutableElement method,
+                            @Nonnull String providerFieldName,
+                            @Nonnull DefaultValue defaultValue,
+                            @Nonnull ClassName repositoryClassName) {
 
         this.namespace = Preconditions.checkNotNull(namespace);
         this.method = Preconditions.checkNotNull(method);
@@ -42,7 +39,6 @@ public class Getter implements Generatable {
     @Override public void generateCode(TypeSpec.Builder builder) throws ProcessingException {
         TypeMirror returnType = method.getReturnType();
 
-
         String methodName = method.getSimpleName().toString();
         String prefName = Utils.getName(method);
 
@@ -53,7 +49,7 @@ public class Getter implements Generatable {
 
         String defaultFieldName = defaultValue.getElement().getSimpleName().toString();
 
-        PrefType prefType = Utils.getRawType(method);
+        PrefType prefType = Utils.getType(method);
         switch (prefType) {
             case BOOLEAN:
                 methodBuilder.addStatement(simpleStatement("Boolean", prefName, defaultFieldName));
@@ -71,8 +67,8 @@ public class Getter implements Generatable {
                 methodBuilder.addStatement(simpleStatement("String", prefName, defaultFieldName));
                 break;
             case OBJECT:
-                methodBuilder.addStatement("return $T.getInstance().get($T.class).get(\"" + prefName + "\", " +
-                                defaultFieldName + ", " + providerFieldName + ")", repositoryClassName,
+                methodBuilder.addStatement("return $T.getInstance().get($T.class).observe(\"" + prefName + "\", " +
+                                           defaultFieldName + ", " + providerFieldName + ")", repositoryClassName,
                         defaultValue.getElement().asType());
                 break;
             default:
@@ -83,6 +79,6 @@ public class Getter implements Generatable {
     }
 
     private String simpleStatement(String type, String prefName, String defaultFieldName) {
-        return "return " + providerFieldName + ".get" + type + "(\"" + prefName + "\", " + defaultFieldName + ")";
+        return "return " + providerFieldName + ".observe" + type + "(\"" + prefName + "\", " + defaultFieldName + ")";
     }
 }

--- a/compiler/src/main/java/com/malinskiy/sheldon2/codegen/validator/ContainsValidator.java
+++ b/compiler/src/main/java/com/malinskiy/sheldon2/codegen/validator/ContainsValidator.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 
 import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
 
 public class ContainsValidator {
     public static void checkValidContainsMethod(@Nonnull ExecutableElement method) throws ProcessingException {
@@ -24,6 +25,21 @@ public class ContainsValidator {
             throw new ProcessingException(
                     method,
                     "Should return Observable"
+            );
+        }
+    }
+
+    public static void checkValidJustContainsMethod(@NonNull ExecutableElement method) throws ProcessingException {
+        List<? extends VariableElement> parameters = method.getParameters();
+        if (parameters.size() != 1) {
+            throw new ProcessingException(method,
+                    "Invalid number of parameters for justContains method. Should be one String parameter");
+        }
+
+        if (!MoreTypes.isTypeOf(Boolean.class, method.getReturnType())) {
+            throw new ProcessingException(
+                    method,
+                    "Should return Boolean"
             );
         }
     }

--- a/compiler/src/main/java/com/malinskiy/sheldon2/codegen/validator/GetValidator.java
+++ b/compiler/src/main/java/com/malinskiy/sheldon2/codegen/validator/GetValidator.java
@@ -3,6 +3,7 @@ package com.malinskiy.sheldon2.codegen.validator;
 import com.google.auto.common.MoreTypes;
 
 import com.malinskiy.sheldon2.annotation.Get;
+import com.malinskiy.sheldon2.annotation.JustGet;
 import com.malinskiy.sheldon2.codegen.ProcessingException;
 import com.malinskiy.sheldon2.codegen.Utils;
 import com.malinskiy.sheldon2.codegen.model.DefaultValue;
@@ -18,7 +19,7 @@ import io.reactivex.Observable;
 
 
 public class GetValidator {
-    public static void checkValidGetter(@Nonnull ExecutableElement method, Map<String, DefaultValue> defaultsMap) throws ProcessingException {
+    public static void checkValidObservableGetter(@Nonnull ExecutableElement method, Map<String, DefaultValue> defaultsMap) throws ProcessingException {
         List<? extends VariableElement> parameters = method.getParameters();
         if (!parameters.isEmpty()) {
             throw new ProcessingException(method,
@@ -36,6 +37,35 @@ public class GetValidator {
             throw new ProcessingException(
                     method,
                     "Should return Observable"
+            );
+        }
+
+        if (!defaultsMap.containsKey(Utils.getName(method))) {
+            throw new ProcessingException(
+                    method,
+                    "No default value found"
+            );
+        }
+    }
+
+    public static void checkValidGetter(@Nonnull ExecutableElement method, Map<String, DefaultValue> defaultsMap) throws ProcessingException {
+        List<? extends VariableElement> parameters = method.getParameters();
+        if (!parameters.isEmpty()) {
+            throw new ProcessingException(method,
+                    "Invalid number of parameters for getter. Should be zero parameters");
+        }
+
+        if (method.getAnnotation(JustGet.class) == null) {
+            throw new ProcessingException(
+                    method,
+                    "No annotation @JustGet present. Did you annotate your method?"
+            );
+        }
+
+        if (MoreTypes.isTypeOf(Void.TYPE, method.getReturnType())) {
+            throw new ProcessingException(
+                    method,
+                    "Should return an object/type"
             );
         }
 

--- a/core/src/main/java/com/malinskiy/sheldon2/IGateway.java
+++ b/core/src/main/java/com/malinskiy/sheldon2/IGateway.java
@@ -16,6 +16,16 @@ public interface IGateway {
 
     @Nonnull Observable<String> observeString(@Nonnull String key, @Nonnull String defaultValue);
 
+    @Nonnull Boolean getBoolean(@Nonnull String key, @Nonnull Boolean defaultValue);
+
+    @Nonnull Float getFloat(@Nonnull String key, @Nonnull Float defaultValue);
+
+    @Nonnull Integer getInteger(@Nonnull String key, @Nonnull Integer defaultValue);
+
+    @Nonnull Long getLong(@Nonnull String key, @Nonnull Long defaultValue);
+
+    @Nonnull String getString(@Nonnull String key, @Nonnull String defaultValue);
+
     void putBoolean(@Nonnull String key, @Nonnull Boolean value);
 
     void putFloat(@Nonnull String key, @Nonnull Float value);
@@ -26,7 +36,10 @@ public interface IGateway {
 
     void putString(@Nonnull String key, @Nonnull String value);
 
-    @Nonnull Observable<Boolean> contains(@Nonnull String key);
+    @Deprecated
+    @Nonnull Observable<Boolean> containsAsObservable(@Nonnull String key);
+
+    boolean contains(@Nonnull String key);
 
     void remove(@Nonnull String key);
 

--- a/core/src/main/java/com/malinskiy/sheldon2/adapter/IPreferenceAdapter.java
+++ b/core/src/main/java/com/malinskiy/sheldon2/adapter/IPreferenceAdapter.java
@@ -5,11 +5,15 @@ import com.malinskiy.sheldon2.IGateway;
 import javax.annotation.Nonnull;
 
 import io.reactivex.Observable;
+import io.reactivex.annotations.NonNull;
 
 public interface IPreferenceAdapter<T> {
 
     @Nonnull
     Observable<T> observe(@Nonnull String key, @Nonnull T defaultValue, @Nonnull IGateway gateway);
+
+    @NonNull
+    T get(@NonNull String key, @NonNull T defaultValue, @NonNull IGateway gateway);
 
     void put(@Nonnull String key, @Nonnull T value, IGateway gateway);
 }

--- a/core/src/main/java/com/malinskiy/sheldon2/adapter/impl/EnumAdapter.java
+++ b/core/src/main/java/com/malinskiy/sheldon2/adapter/impl/EnumAdapter.java
@@ -27,6 +27,11 @@ public class EnumAdapter<T extends Enum<T>> implements IPreferenceAdapter<T> {
         });
     }
 
+    @Override
+    public T get(String key, T defaultValue, IGateway gateway) {
+        return fromString(gateway.getString(key, toString(defaultValue)));
+    }
+
     @Override public void put(@Nonnull String key, @Nonnull T value, IGateway gateway) {
         gateway.putString(key, toString(value));
     }

--- a/core/src/main/java/com/malinskiy/sheldon2/annotation/JustContains.java
+++ b/core/src/main/java/com/malinskiy/sheldon2/annotation/JustContains.java
@@ -1,0 +1,11 @@
+package com.malinskiy.sheldon2.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface JustContains {
+}

--- a/core/src/main/java/com/malinskiy/sheldon2/annotation/JustGet.java
+++ b/core/src/main/java/com/malinskiy/sheldon2/annotation/JustGet.java
@@ -1,0 +1,14 @@
+package com.malinskiy.sheldon2.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface JustGet {
+
+    String name();
+
+}

--- a/core/src/test/java/com/malinskiy/sheldon2/adapter/impl/EnumAdapterTest.java
+++ b/core/src/test/java/com/malinskiy/sheldon2/adapter/impl/EnumAdapterTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,6 +46,18 @@ public class EnumAdapterTest {
         verify(observer).onNext(NUMBER.TWO);
         verify(observer).onComplete();
         verify(observer, never()).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void testGet() {
+        NUMBER expectedNumber = NUMBER.TWO;
+        when(gateway.getString("testKey", NUMBER.ONE.name()))
+                .thenReturn(expectedNumber.name());
+
+        NUMBER actualNumber = adapter.get("testKey", NUMBER.ONE, gateway);
+
+        verify(gateway).getString("testKey", NUMBER.ONE.name());
+        assertEquals(actualNumber, expectedNumber);
     }
 
     @Test

--- a/gateway-sharedpreferences/src/main/java/com/malinskiy/sheldon2/provider/SharedPreferencesGateway.java
+++ b/gateway-sharedpreferences/src/main/java/com/malinskiy/sheldon2/provider/SharedPreferencesGateway.java
@@ -143,6 +143,36 @@ public class SharedPreferencesGateway implements IGateway {
                 });
     }
 
+    @Nonnull
+    @Override
+    public Boolean getBoolean(@Nonnull String key, @Nonnull Boolean defaultValue) {
+        return preferences.getBoolean(key, defaultValue);
+    }
+
+    @Nonnull
+    @Override
+    public Float getFloat(@Nonnull String key, @Nonnull Float defaultValue) {
+        return preferences.getFloat(key, defaultValue);
+    }
+
+    @Nonnull
+    @Override
+    public Integer getInteger(@Nonnull String key, @Nonnull Integer defaultValue) {
+        return preferences.getInt(key, defaultValue);
+    }
+
+    @Nonnull
+    @Override
+    public Long getLong(@Nonnull String key, @Nonnull Long defaultValue) {
+        return preferences.getLong(key, defaultValue);
+    }
+
+    @Nonnull
+    @Override
+    public String getString(@Nonnull String key, @Nonnull String defaultValue) {
+        return preferences.getString(key, defaultValue);
+    }
+
     @Override public void putBoolean(@Nonnull String key, @Nonnull Boolean value) {
         preferences.edit()
                    .putBoolean(key, value)
@@ -173,12 +203,24 @@ public class SharedPreferencesGateway implements IGateway {
                    .apply();
     }
 
-    @Nonnull @Override public Observable<Boolean> contains(@Nonnull final String key) {
+    /**
+     *
+     * @deprecated Don't need to call .contains in separate thread (and thus increase complexity
+     * of the program) .contains is quick operation, only the initial getSharedPrefernces call is
+     * slow and needs to be off loaded from the UI thread.
+     *
+     */
+    @Deprecated
+    @Nonnull @Override public Observable<Boolean> containsAsObservable(@Nonnull final String key) {
         return Observable.fromCallable(new Callable<Boolean>() {
             @Override public Boolean call() {
                 return preferences.contains(key);
             }
         });
+    }
+
+    @Nonnull @Override public boolean contains(@Nonnull final String key) {
+        return preferences.contains(key);
     }
 
     @Override public void remove(@Nonnull String key) {

--- a/gateway-sharedpreferences/src/test/java/com/malinskiy/sheldon2/provider/BaseSharedPreferenceTypeTest.java
+++ b/gateway-sharedpreferences/src/test/java/com/malinskiy/sheldon2/provider/BaseSharedPreferenceTypeTest.java
@@ -80,7 +80,7 @@ public abstract class BaseSharedPreferenceTypeTest<T> {
 
     @Test
     public void testContains() throws Exception {
-        TestObserver<Boolean> observer = gateway.contains(PREFERENCE_KEY).test();
+        TestObserver<Boolean> observer = gateway.containsAsObservable(PREFERENCE_KEY).test();
 
         observer.assertValue(false);
         observer.assertComplete();

--- a/sample/src/main/java/com/malinskiy/sheldon2/sample/MainPreferences.java
+++ b/sample/src/main/java/com/malinskiy/sheldon2/sample/MainPreferences.java
@@ -4,6 +4,8 @@ import com.malinskiy.sheldon2.annotation.Contains;
 import com.malinskiy.sheldon2.annotation.Default;
 import com.malinskiy.sheldon2.annotation.Delete;
 import com.malinskiy.sheldon2.annotation.Get;
+import com.malinskiy.sheldon2.annotation.JustContains;
+import com.malinskiy.sheldon2.annotation.JustGet;
 import com.malinskiy.sheldon2.annotation.Preferences;
 import com.malinskiy.sheldon2.annotation.Set;
 
@@ -20,6 +22,8 @@ public interface MainPreferences {
 
     @Set(name = "name") void setPolicyName(String name);
 
+    @JustGet(name = "name") String getPolicyNameSync();
+
 
     @Default(name = "enum") Type DEFAULT_ENUM = Type.THREE;
 
@@ -28,6 +32,8 @@ public interface MainPreferences {
     @Set(name = "enum") void setEnum(Type value);
 
     @Contains Observable<Boolean> contains(String key);
+
+    @JustContains Boolean justContains(String key);
 
     @Delete void remove(String key);
 }

--- a/sample/src/main/java/com/malinskiy/sheldon2/sample/TypeAdapter.java
+++ b/sample/src/main/java/com/malinskiy/sheldon2/sample/TypeAdapter.java
@@ -22,6 +22,11 @@ public class TypeAdapter implements IPreferenceAdapter<Type> {
                       });
     }
 
+    @Override
+    public Type get(String key, Type defaultValue, IGateway gateway) {
+        return Type.valueOf(gateway.getString(key, defaultValue.name()));
+    }
+
     @Override public void put(@Nonnull String key, @Nonnull Type value, IGateway gateway) {
         gateway.putString(key, value.name());
     }


### PR DESCRIPTION
From the brief research I did on the source coded of shared preferences source code and from explanations of the  stackoverflow threads [here](https://stackoverflow.com/questions/4371273/should-accessing-sharedpreferences-be-done-off-the-ui-thread) and [commonsWare's answer here](https://stackoverflow.com/a/19148351) I think its pretty clear the operation that needs to be offloaded from the main thread is the `context.getSharedPreferences` and not the actual reads (as they're fairly fast enough that they wont contribute to any frame drops). So I propose this PR in hopes that we can have support for synchronous reads and stop having to work with rx java for simple reads, (even using when toBlocking() we expose ourselves to bugs caused from threadinterupted execptions)

P.S: this is more of a POC, havent done any UT coverage or anything on this yet, if you need further proof on why `context.getSharedPreferences` is the operation that needs to be offloaded and not the threads, I could probably create a repo with method profiling to demonstrate it I suppose, but It feels like the documentation and the source code should be fairly self explanatory.